### PR TITLE
Security test case: Fake authentication headers

### DIFF
--- a/env/dev/default.properties
+++ b/env/dev/default.properties
@@ -2,8 +2,8 @@
 # properties set here will be available to the test execution as environment variables
 
 # Please set the following environment variables in the local env config file or in your actual environment
-eu_gateway_url = http://tng-dev.who.int
-first_gateway_url = http://tng-dev.who.int
+eu_gateway_url = https://tng-dev.who.int
+first_gateway_url = https://tng-dev.who.int
 # second_gateway_url = http://address.of.test.second.gateway
 # third_gateway_url = http://address.of.test.third.gateway
 

--- a/env/uat/default.properties
+++ b/env/uat/default.properties
@@ -2,8 +2,8 @@
 # properties set here will be available to the test execution as environment variables
 
 # Please set the following environment variables in the local env config file or in your actual environment
-eu_gateway_url = http://tng-uat.who.int
-first_gateway_url = http://tng-uat.who.int
+eu_gateway_url = https://tng-uat.who.int
+first_gateway_url = https://tng-uat.who.int
 # second_gateway_url = http://address.of.test.second.gateway
 # third_gateway_url = http://address.of.test.third.gateway
 

--- a/specs/gateway/security.md
+++ b/specs/gateway/security.md
@@ -1,0 +1,14 @@
+# Basic security test cases
+
+CountryA and CountryB are both authorized to use the gateway.
+CountryC is unauthorized.
+
+## Fake authentication headers 
+
+CountryC has been able to get the public parts of CountryA's 
+AUTH certificate and is trying to fake the headers that the 
+ingress is setting. 
+
+* extract subject and fingerprint from "auth" certificate of "CountryA" 
+* "CountryC" uses its "auth" cert with fake headers for access
+* check that the response had an error

--- a/step_impl/gw/security.py
+++ b/step_impl/gw/security.py
@@ -1,0 +1,36 @@
+from step_impl.gw.gateway_util import failed_response
+from getgauge.python import step, data_store
+from step_impl.util.testdata import get_country_cert_files
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography import x509
+from os import environ
+import requests
+
+@step("extract subject and fingerprint from <certtype> certificate of <country>")
+def extract_subject_and_fingerprint_from_certificate_of(certtype, country):
+    cert_file, key_file = get_country_cert_files(country, certtype )
+    cert = x509.load_pem_x509_certificate(open(cert_file, "rb").read())
+    
+    data_store.scenario['extracted.fingerprint'] = cert.fingerprint(hashes.SHA256()).hex() 
+    data_store.scenario['extracted.subject'] = cert.subject.rfc4514_string()
+    #print(data_store.scenario['extracted.subject'])
+    
+    
+
+@step("<country> uses its <certtype> cert with fake headers for access")
+def downloads_the_certificate_trust_list_with_fake_headers(country, certtype):
+    try:
+        data_store.scenario["response"] = requests.get(
+            url=data_store.scenario["gateway.url"] + '/trustList/certificate',
+            cert=get_country_cert_files(country, certtype),
+            verify=bool(environ.get('verify_https')),
+            params=data_store.scenario["search.filter"],
+            headers={
+               'X-SSL-Client-SHA256': data_store.scenario['extracted.fingerprint'],
+               'X-SSL-Client-DN' : data_store.scenario['extracted.subject']
+            }
+
+        )
+        #print(data_store.scenario["response"].text[:100])
+    except IOError as error:
+        failed_response(error)


### PR DESCRIPTION
Added security test case in which a client sends fake authentication headers. 

Prerequisites: 
CountryA has access to the services
CountryC does NOT have access to the services but has a client cert from a trusted CA

Test case: 
CountryC somehow gets hold of the public part of CountryA's auth cert and fakes the ingress headers